### PR TITLE
Preserve the natural ordering of unsigned 32bit tags during iteration.

### DIFF
--- a/MINTJavaSDK/build.gradle
+++ b/MINTJavaSDK/build.gradle
@@ -18,7 +18,7 @@ dependencies {
             [group: 'com.google.protobuf', name: 'protobuf-java', version: '2.3.0'],
             [group: 'commons-codec', name: 'commons-codec', version: '1.6'],
             [group: 'joda-time', name: 'joda-time', version: '2.1'],
-            [group: 'org.jibx', name: 'jibx-run', version: '1.2.3']
+            [group: 'org.jibx', name: 'jibx-run', version: '1.3.0']
     )
 
     testCompile (
@@ -26,7 +26,7 @@ dependencies {
     )
 
     jibxBinding (
-            [group: 'org.jibx', name: 'jibx-bind', version: '1.2.5']
+            [group: 'org.jibx', name: 'jibx-bind', version: '1.3.0']
     )
 }
 

--- a/MINTJavaSDK/src/main/java/org/nema/medical/mint/metadata/Instance.java
+++ b/MINTJavaSDK/src/main/java/org/nema/medical/mint/metadata/Instance.java
@@ -37,7 +37,7 @@ import org.nema.medical.mint.metadata.GPB.InstanceData;
  */
 public class Instance implements AttributeContainer, Excludable
 {
-    private final Map<Integer,Attribute> attributeMap = new TreeMap<Integer,Attribute>();
+    private final Map<Long,Attribute> attributeMap = new TreeMap<Long, Attribute>();
     private String sopInstanceUID;
     private String transferSyntaxUID;
     private boolean excluded;
@@ -47,7 +47,7 @@ public class Instance implements AttributeContainer, Excludable
      * @return the attribute for the given tag (in hex)
      */
     public Attribute getAttribute(final int tag) {
-        return attributeMap.get(tag);
+        return attributeMap.get(toUint32(tag));
     }
 
     // todo pull into superclass
@@ -61,7 +61,7 @@ public class Instance implements AttributeContainer, Excludable
      * @param attr
      */
     public void putAttribute(final Attribute attr) {
-        attributeMap.put(attr.getTag(), attr);
+        attributeMap.put(toUint32(attr.getTag()), attr);
     }
 
     /**
@@ -69,7 +69,7 @@ public class Instance implements AttributeContainer, Excludable
      * @param tag
      */
     public void removeAttribute(final int tag) {
-        attributeMap.remove(tag);
+        attributeMap.remove(toUint32(tag));
     }
 
     /**
@@ -169,5 +169,9 @@ public class Instance implements AttributeContainer, Excludable
         }
         InstanceData data = builder.build();
         return data;
+    }
+
+    private Long toUint32(int tag) {
+        return tag & 0x00000000FFFFFFFFL;
     }
 }

--- a/MINTJavaSDK/src/main/java/org/nema/medical/mint/metadata/Item.java
+++ b/MINTJavaSDK/src/main/java/org/nema/medical/mint/metadata/Item.java
@@ -35,13 +35,13 @@ import org.nema.medical.mint.metadata.GPB.ItemData;
  * </pre>
  */
 public class Item implements AttributeContainer, Cloneable {
-    private Map<Integer, Attribute> attributeMap = new TreeMap<Integer, Attribute>();
+    private Map<Long, Attribute> attributeMap = new TreeMap<Long, Attribute>();
 
     @Override
     public Object clone() throws CloneNotSupportedException {
         final Item clone = (Item) super.clone();
-        clone.attributeMap = new TreeMap<Integer, Attribute>(attributeMap);
-        for (final Map.Entry<Integer, Attribute> entry: attributeMap.entrySet()) {
+        clone.attributeMap = new TreeMap<Long, Attribute>(attributeMap);
+        for (final Map.Entry<Long, Attribute> entry: attributeMap.entrySet()) {
             clone.attributeMap.put(entry.getKey(), (Attribute) entry.getValue().clone());
         }
         return clone;
@@ -68,7 +68,7 @@ public class Item implements AttributeContainer, Cloneable {
      * @return the attribute for the given tag
      */
     public Attribute getAttribute(final int tag) {
-        return attributeMap.get(tag);
+        return attributeMap.get(toUint32(tag));
     }
 
     /**
@@ -77,7 +77,7 @@ public class Item implements AttributeContainer, Cloneable {
      * @param attr
      */
     public void putAttribute(final Attribute attr) {
-        attributeMap.put(attr.getTag(), attr);
+        attributeMap.put(toUint32(attr.getTag()), attr);
     }
 
     /**
@@ -86,7 +86,7 @@ public class Item implements AttributeContainer, Cloneable {
      * @param tag
      */
     public void removeAttribute(final int tag) {
-        attributeMap.remove(tag);
+        attributeMap.remove(toUint32(tag));
     }
 
     /**
@@ -118,5 +118,9 @@ public class Item implements AttributeContainer, Cloneable {
         }
         ItemData data = builder.build();
         return data;
+    }
+
+    private Long toUint32(int tag) {
+        return tag & 0x00000000FFFFFFFFL;
     }
 }

--- a/MINTJavaSDK/src/main/java/org/nema/medical/mint/metadata/Series.java
+++ b/MINTJavaSDK/src/main/java/org/nema/medical/mint/metadata/Series.java
@@ -40,8 +40,8 @@ import org.nema.medical.mint.metadata.GPB.SeriesData;
  */
 public class Series implements AttributeContainer, Excludable
 {
-    private final Map<Integer,Attribute> attributeMap = new TreeMap<Integer,Attribute>();
-    private final Map<Integer,Attribute> normalizedInstanceAttributeMap = new TreeMap<Integer,Attribute>();
+    private final Map<Long,Attribute> attributeMap = new TreeMap<Long,Attribute>();
+    private final Map<Long,Attribute> normalizedInstanceAttributeMap = new TreeMap<Long,Attribute>();
     private final Map<String, Instance> instances = new TreeMap<String, Instance>();
     private String seriesInstanceUID;
     private boolean excluded;
@@ -51,7 +51,7 @@ public class Series implements AttributeContainer, Excludable
      * @return the attribute for the given tag
      */
     public Attribute getAttribute(final int tag) {
-        return attributeMap.get(tag);
+        return attributeMap.get(toUint32(tag));
     }
 
     /**
@@ -59,7 +59,7 @@ public class Series implements AttributeContainer, Excludable
      * @param attr
      */
     public void putAttribute(final Attribute attr) {
-        attributeMap.put(attr.getTag(), attr);
+        attributeMap.put(toUint32(attr.getTag()), attr);
     }
 
     /**
@@ -67,7 +67,7 @@ public class Series implements AttributeContainer, Excludable
      * @param tag
      */
     public void removeAttribute(final int tag) {
-        attributeMap.remove(tag);
+        attributeMap.remove(toUint32(tag));
     }
 
     /**
@@ -86,7 +86,7 @@ public class Series implements AttributeContainer, Excludable
      * @return the normalized instance attribute for the given tag
      */
     public Attribute getNormalizedInstanceAttribute(final int tag) {
-        return normalizedInstanceAttributeMap.get(tag);
+        return normalizedInstanceAttributeMap.get(toUint32(tag));
     }
 
     /**
@@ -94,7 +94,7 @@ public class Series implements AttributeContainer, Excludable
      * @param attr
      */
     public void putNormalizedInstanceAttribute(final Attribute attr) {
-        normalizedInstanceAttributeMap.put(attr.getTag(), attr);
+        normalizedInstanceAttributeMap.put(toUint32(attr.getTag()), attr);
     }
 
     /**
@@ -102,7 +102,7 @@ public class Series implements AttributeContainer, Excludable
      * @param tag
      */
     public void removeNormalizedInstanceAttribute(final int tag) {
-        normalizedInstanceAttributeMap.remove(tag);
+        normalizedInstanceAttributeMap.remove(toUint32(tag));
     }
 
     /**
@@ -251,5 +251,9 @@ public class Series implements AttributeContainer, Excludable
         }
         SeriesData data = builder.build();
         return data;
+    }
+
+    private Long toUint32(int tag) {
+        return tag & 0x00000000FFFFFFFFL;
     }
 }

--- a/MINTJavaSDK/src/main/java/org/nema/medical/mint/metadata/StudyMetadata.java
+++ b/MINTJavaSDK/src/main/java/org/nema/medical/mint/metadata/StudyMetadata.java
@@ -44,7 +44,7 @@ import org.nema.medical.mint.metadata.GPB.StudyData;
  */
 public class StudyMetadata implements AttributeContainer, StudySummary
 {
-    private final Map<Integer,Attribute> attributeMap = new TreeMap<Integer,Attribute>();
+    private final Map<Long,Attribute> attributeMap = new TreeMap<Long,Attribute>();
     private final Map<String,Series> seriesMap = new TreeMap<String,Series>();
     private String studyInstanceUID;
 
@@ -52,7 +52,7 @@ public class StudyMetadata implements AttributeContainer, StudySummary
 	 * @see org.nema.medical.mint.metadata.StudySummary#getAttribute(int)
 	 */
     public Attribute getAttribute(final int tag) {
-        return attributeMap.get(tag);
+        return attributeMap.get(toUint32(tag));
     }
 
     /* (non-Javadoc)
@@ -68,7 +68,7 @@ public class StudyMetadata implements AttributeContainer, StudySummary
      * @param attr
      */
     public void putAttribute(final Attribute attr) {
-        attributeMap.put(attr.getTag(), attr);
+        attributeMap.put(toUint32(attr.getTag()), attr);
     }
 
     /**
@@ -76,7 +76,7 @@ public class StudyMetadata implements AttributeContainer, StudySummary
      * @param tag
      */
     public void removeAttribute(final int tag) {
-        attributeMap.remove(tag);
+        attributeMap.remove(toUint32(tag));
     }
     
     /* (non-Javadoc)
@@ -254,5 +254,7 @@ public class StudyMetadata implements AttributeContainer, StudySummary
         return builder.build();
     }
 
-
+    private Long toUint32(int tag) {
+        return tag & 0x00000000FFFFFFFFL;
+    }
 }


### PR DESCRIPTION
… iteration using Item, Instance, Series and StudyMetadata classes. Group 8000+ elements overflow the native Java int type causing them to be positioned closer to the front of the sorted map than e.g: Group 0008 elements in the TreeMap<Integer, Attribute> and resulting in an unexpected iteration order when the attributeIterator( ) method is subsequently invoked.